### PR TITLE
Fix for 320x200 resolutions and FPS Fix for PrBoom Defaults

### DIFF
--- a/gfx/video_crt_switch.c
+++ b/gfx/video_crt_switch.c
@@ -88,6 +88,10 @@ static void switch_crt_hz(void)
       if (ra_core_hz >= 114)
          ra_set_core_hz = 120;
    }
+   
+   /* Temp fix for PrBoom's odd 40hz default refresh*/
+   if (ra_core_hz == 40)
+      ra_core_hz = 60;
 
    video_monitor_set_refresh_rate(ra_set_core_hz);
 
@@ -104,7 +108,7 @@ bool crt_debug_mode_active(void)
 
 void crt_aspect_ratio_switch(unsigned width, unsigned height)
 {
-   /* send aspect float to videeo_driver */
+   /* send aspect float to video_driver */
    fly_aspect = (float)width / height;
    video_driver_set_aspect_ratio_value((float)fly_aspect);
 }
@@ -158,7 +162,7 @@ static void crt_screen_setup_aspect(unsigned width, unsigned height)
       crt_aspect_ratio_switch(width, height);
    }
 
-   if (height > 200 && height < 224)
+   if (height >= 200 && height < 224)
    {
       crt_aspect_ratio_switch(width, height);
       height = 224;


### PR DESCRIPTION
320x200 was not displaying in the correct aspect ratio.

Also added fix for PrBoom. It defaults to 40fps which is fine for LCDs but 15khz CRTs cannot sync as low as 40hz. Any time 40hz is called for it will now default to 60 to avoid damage to screens and allowing the games to be playable.

## Guidelines

1. Rebase before opening a pull request
2. If you are sending several unrelated fixes or features, use a branch and a separate pull request for each
3. If possible try squashing everything in a single commit. This is particularly beneficial in the case of feature merges since it allows easy bisecting when a problem arises

## Description

[Description of the pull request, detail any issues you are fixing or any features you are implementing]

## Related Issues

[Any issues this pull request may be addressing]

## Related Pull Requests

[Any other PRs from related repositories that might be needed for this pull request to work]

## Reviewers

[If possible @mention all the people that should review your pull request]
