### PR TITLE
fix xrandr modes are not cleaned correctly.

### DIFF
--- a/gfx/display_servers/dispserv_win32.c
+++ b/gfx/display_servers/dispserv_win32.c
@@ -126,7 +126,7 @@ static void win32_display_server_destroy(void *data)
             dispserv->orig_height,
             dispserv->orig_refresh,
             (float)dispserv->orig_refresh,
-            dispserv->crt_center, 0, 0);
+            dispserv->crt_center, 0, 0, 0);
 
 #ifdef HAS_TASKBAR_EXT
    if (dispserv->taskbar_list)

--- a/gfx/display_servers/dispserv_x11.c
+++ b/gfx/display_servers/dispserv_x11.c
@@ -300,7 +300,7 @@ static bool x11_display_server_set_resolution(void *data,
                   outputs->name, new_mode);
             system(xrandr);
 
-            // delete old mode if exists
+            /* delete old mode, if set */
             if (strnlen(old_mode, sizeof(old_mode)))
             {
                snprintf(xrandr, sizeof(xrandr),
@@ -332,7 +332,7 @@ static bool x11_display_server_set_resolution(void *data,
                outputs->name, new_mode);
          system(xrandr);
 
-         // delete old mode if exists
+         /* delete old mode, if set */
          if (strnlen(old_mode, sizeof(old_mode)))
          {
             snprintf(xrandr, sizeof(xrandr),


### PR DESCRIPTION
## Description

This patch has been created because when exiting retroarch the X11 modelines created during emulation remain. This patch clears them correctly on exit.

![imagen](https://user-images.githubusercontent.com/560310/88849787-adffdb00-d1ea-11ea-99ff-41e980c14989.png)

## Reviewers

@alphanu1 

used in rgbux (fullpatch: https://github.com/rgb-x/system/blob/master/diffs/rgbux-patch-retroarch.diff)

Really thanks for your lastest porch feature! :+1: 